### PR TITLE
Update Vancouver.XSL

### DIFF
--- a/styles/Vancouver.XSL
+++ b/styles/Vancouver.XSL
@@ -72,6 +72,7 @@
         <b:ImportantField>b:Issue</b:ImportantField>
         <b:ImportantField>b:Month</b:ImportantField>
         <b:ImportantField>b:Year</b:ImportantField>
+        <b:ImportantField>b:Pages</b:ImportantField>
       </source>
       <source type="ArticleInAPeriodical">
         <b:ImportantField>b:Author/b:Author/b:NameList</b:ImportantField>
@@ -224,7 +225,7 @@
         <column id="2">
           <halign>left</halign>
           <valign>top</valign>
-          <format>{%Author:1%. }{%Title%. }{%JournalName%. }{%Year%{ %Month:s%{ %Day%}}};{ %Volume%}{(%Issue%)}{: %Pages:p. :p. %}.</format>
+          <format>{%Author:1%. }{%Title%. }{%JournalName%. }{%Year%{ %Month:s%{ %Day%}}};{ %Volume%}{(%Issue%)}{: %Pages: : %}.</format>
         </column>
         <sortkey></sortkey>
       </source>


### PR DESCRIPTION
Pages are an important field when citing journal articles, also the "p. " it is not used anymore

The actual format is:
Huded CP, Tuzcu EM, Krishnaswamy A, et al. Association Between Transcatheter Aortic Valve Replacement and Early Postprocedural Stroke. JAMA. 2019;321(23):2306–2315

Where the: 2306-2315 are the pages of the journal article.

I believe this would be solved deleting the "p." in line 227